### PR TITLE
Add :crypto to :extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,14 +22,12 @@ defmodule NimbleTOTP.MixProject do
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:crypto]
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:ex_doc, ">= 0.19.0", only: :docs}


### PR DESCRIPTION
Brought to you by a warning that we have on Elixir v1.11 :-)

    warning: :crypto.hmac/3 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

      1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

      2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

      3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto] to your "def project" in mix.exs

      lib/nimble_totp.ex:142: NimbleTOTP.hmac/3