### PR TITLE
changed description of secret() test.

### DIFF
--- a/test/nimble_totp_test.exs
+++ b/test/nimble_totp_test.exs
@@ -23,7 +23,7 @@ defmodule NimbleTOTPTest do
   end
 
   describe "secret" do
-    test "generate a binary with 20 bytes" do
+    test "generate a binary with 10 bytes" do
       secret = NimbleTOTP.secret()
 
       assert byte_size(secret) == 10


### PR DESCRIPTION
The description matches the 10 bytes which are actual generated (not 20)