### PR TITLE
Update secret/0 to generate 20 random bytes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: 22.3
           elixir-version: 1.10.2
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.pair.erlang}}
           elixir-version: ${{matrix.pair.elixir}}

--- a/lib/nimble_totp.ex
+++ b/lib/nimble_totp.ex
@@ -40,9 +40,10 @@ defmodule NimbleTOTP do
   Example:
 
       secret = NimbleTOTP.secret()
-      #=> <<63, 24, 42, 30, 95, 116, 80, 121, 106, 102>>
+      #=> <<178, 117, 46, 7, 172, 202, 108, 127, 186, 180, ...>>
 
-  By default, a binary with 10 random bytes is generated.
+  By default, a binary with 20 random bytes is generated per the
+  [HOTP RFC](https://tools.ietf.org/html/rfc4226#section-4).
 
   ### Generating URIs for QR Code
 
@@ -105,15 +106,16 @@ defmodule NimbleTOTP do
   @doc """
   Generate a binary composed of random bytes.
 
-  The number of bytes is defined by the `size` argument. Default is `10`.
+  The number of bytes is defined by the `size` argument. Default is `20` per the
+  [HOTP RFC](https://tools.ietf.org/html/rfc4226#section-4).
 
   ## Examples
 
       NimbleTOTP.secret()
-      #=> <<63, 24, 42, 30, 95, 116, 80, 121, 106, 102>>
+      #=> <<178, 117, 46, 7, 172, 202, 108, 127, 186, 180, ...>>
 
   """
-  def secret(size \\ 10) do
+  def secret(size \\ 20) do
     :crypto.strong_rand_bytes(size)
   end
 

--- a/test/nimble_totp_test.exs
+++ b/test/nimble_totp_test.exs
@@ -24,9 +24,15 @@ defmodule NimbleTOTPTest do
 
   describe "secret" do
     test "generate a binary with 10 bytes" do
-      secret = NimbleTOTP.secret()
+      secret = NimbleTOTP.secret(10)
 
       assert byte_size(secret) == 10
+    end
+
+    test "generate a binary with 20 bytes by default" do
+      secret = NimbleTOTP.secret()
+
+      assert byte_size(secret) == 20
     end
 
     test "always generate a different randon secret" do


### PR DESCRIPTION
Update `secret/0` to generate 20 random bytes instead of the current 10
to conform to the guidelines published in the HOTP RFC.

Closes #5 