### PR TITLE
Makes example more helpful

### DIFF
--- a/lib/nimble_totp.ex
+++ b/lib/nimble_totp.ex
@@ -154,7 +154,7 @@ defmodule NimbleTOTP do
     * :period - The period (in seconds) in which the code is valid. Default is `30`.
 
   ## Examples
-
+      secret = Base.decode32!("PTEPUGZ7DUWTBGMW4WLKB6U63MGKKMCA")
       NimbleTOTP.verification_code(secret)
       #=> "569777"
 


### PR DESCRIPTION
When getting a code for a MFA secret generated elsewhere I got wrong codes and only after digging in the tests did I figure out that the value needs to be decoded with base32. This example might save future users some headache.